### PR TITLE
Disables links to tool detail pages from tool listing

### DIFF
--- a/_includes/tools.html
+++ b/_includes/tools.html
@@ -1,6 +1,10 @@
 <div class="flex-boxes">
   {% for post in site.categories.tools %}
-    <a href="{{ post.url | prepend: site.baseurl }}" class="flex-box{% cycle ' flex-box-big', '', '' %}">
+  	<!--
+	AS: Temp disabled link until we have content
+	<a href="{{ post.url | prepend: site.baseurl }}" class="flex-box{% cycle ' flex-box-big', '', '' %}">
+	-->
+	<a class="flex-box{% cycle ' flex-box-big', '', '' %}">
       <h1 class="flex-title">{{ post.title }}</h1>
       <p>{{ post.blurb }}</p>
     </a>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -78,7 +78,12 @@
           {% assign tools = site.categories.tools | where:"feature",true  %}
 		  {% assign sortedTools = tools | sort: 'date' %}
           {% for post in sortedTools limit:3 %}
-          <a class="card" href="{{ post.url | prepend: site.baseurl }}">
+
+          <!--
+		  	AS: Temp disabled link until we have content
+		  	<a class="card" href="{{ post.url | prepend: site.baseurl }}">
+		  -->	
+		  <a class="card" href="{{ site.baseurl }}/tools/">
             {% assign image_url = post.image %}
             {% unless post.image %}
               {% assign image_url = "https://raw.githubusercontent.com/thoughtbot/refills/master/source/images/mountains.png" %}


### PR DESCRIPTION
closes #6 

Temporarily disables links to tool detail pages from tool listing until we have content.